### PR TITLE
Add Query Permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,17 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+    <!--
+    Allow the following apps to be accessed by this app via the packageManager.
+    You may need to add other package names based on your device.
+    -->
+
+    <queries >
+        <package android:name="com.example.background" />
+        <package android:name="com.android.gallery3d" />
+        <package android:name="com.android.camera2" />
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -38,7 +49,5 @@
             </intent-filter>
         </activity>
 
-
     </application>
-
 </manifest>

--- a/app/src/main/java/com/example/background/BlurActivity.kt
+++ b/app/src/main/java/com/example/background/BlurActivity.kt
@@ -16,7 +16,6 @@
 
 package com.example.background
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
@@ -35,17 +34,13 @@ class BlurActivity : AppCompatActivity() {
     }
     private lateinit var binding: ActivityBlurBinding
 
-    @SuppressLint("QueryPermissionsNeeded")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityBlurBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-
         binding.goButton.setOnClickListener { viewModel.applyBlur(blurLevel) }
-
         binding.cancelButton.setOnClickListener { viewModel.cancelWork() }
-
         viewModel.outputWorkInfos.observe(this, workInfosObserver())
 
         binding.seeFileButton.setOnClickListener {
@@ -65,12 +60,11 @@ class BlurActivity : AppCompatActivity() {
             }
 
             val workInfo = listOfWorkInfo[0]
-
             if (workInfo.state.isFinished) {
                 showWorkFinished()
-                val outputImageUri = workInfo.outputData.getString(KEY_IMAGE_URI)
 
-                if(!outputImageUri.isNullOrEmpty()) {
+                val outputImageUri = workInfo.outputData.getString(KEY_IMAGE_URI)
+                if (!outputImageUri.isNullOrEmpty()) {
                     viewModel.setOutputUri(outputImageUri)
                     binding.seeFileButton.visibility = View.VISIBLE
                 }

--- a/app/src/main/java/com/example/background/BlurViewModel.kt
+++ b/app/src/main/java/com/example/background/BlurViewModel.kt
@@ -42,16 +42,12 @@ class BlurViewModel(application: Application) : ViewModel() {
         imageUri = getImageUri(application.applicationContext)
         outputWorkInfos = workManager.getWorkInfosByTagLiveData(TAG_OUTPUT)
     }
+
     /**
      * Create the WorkRequest to apply the blur and save the resulting image
      * @param blurLevel The amount to blur the image
      */
     internal fun applyBlur(blurLevel: Int) {
-
-        //var  continuation = workManager
-        //  .beginWith(OneTimeWorkRequest
-        //    .from(CleanupWorker::class.java))
-
 
         var continuation = workManager
             .beginUniqueWork(
@@ -78,23 +74,16 @@ class BlurViewModel(application: Application) : ViewModel() {
             .setConstraints(constraints)
             .addTag(TAG_OUTPUT)
             .build()
-        continuation.enqueue()
-
 
         continuation = continuation.then(save)
 
+        // start work
         continuation.enqueue()
-        //workManager.enqueue
-
-
     }
-
 
     internal fun cancelWork() {
         workManager.cancelUniqueWork(IMAGE_MANIPULATION_WORK_NAME)
     }
-
-
 
     private fun createInputDataForUri(): Data {
         val builder = Data.Builder()


### PR DESCRIPTION
# This fixes:
- See Image button not working

## Problems found:
- `Suppressed query permission` - This prevented the app from starting intents to view the image.
Fixed by adding gallery package name in the manifest's query element.

- `Double work enqueue` - While this wasn't a big deal since work manager was set to replace the current work if any, it could have been dangerous when using policies such as `KEEP` or `APPEND`. Fixed by ensuring a single enqueue.

Rebased commits 😋

```diff 
+ remove suppress lint for query permission warning
+ remove double enqueue
```